### PR TITLE
build: fix ci error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  DATABASE_URL: sqlite:./test.db
+  DATABASE_URL: "sqlite://./test.db"
 
 jobs:
   check:
@@ -26,12 +26,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo sqlx database create
-      - run: cargo sqlx migrate run
-      - run: cargo sqlx prepare
-
       - name: Cargo check
-        run: cargo check
+        run: |
+          touch test.db
+          cargo sqlx database create
+          cargo sqlx migrate run
+          cargo sqlx prepare
+          cargo check
 
 
   test:
@@ -51,12 +52,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo sqlx database create
-      - run: cargo sqlx migrate run
-      - run: cargo sqlx prepare
-
       - name: Run cargo test
-        run: cargo nextest run
+        run: |
+          touch test.db
+          cargo sqlx database create
+          cargo sqlx migrate run
+          cargo sqlx prepare
+          cargo nextest run
 
 
   lints:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,7 +10,7 @@ on:
       - master
 
 env:
-  DATABASE_URL: sqlite:./release-plz.db
+  DATABASE_URL: "sqlite://./release-plz.db"
 
 jobs:
   release-plz:
@@ -36,9 +36,12 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: sqlx-cli
-      - run: cargo sqlx database create
-      - run: cargo sqlx migrate run
-      - run: cargo sqlx prepare
+      - name: setup db
+        run: |
+          touch release-plz.db
+          cargo sqlx database create
+          cargo sqlx migrate run
+          cargo sqlx prepare
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chacha20poly1305 = { version = "0.10.1", features = ["std"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 dirs = "5.0.1"
 futures = "0.3.30"
-keyring = "2.3.3"
+keyring = { version = "2.3.3", features = ["linux-default-keyutils"] }
 sqlx = { version = "0.7.4", features = ["sqlite", "chrono", "runtime-tokio-native-tls"] }
 tempfile = "3.12.0"
 thiserror = "1.0.61"


### PR DESCRIPTION
keyring のデフォルトが D-Bus を使う secret-service だったのでヘッドレス環境だと動かなかった。
デフォルトでは keyutils を使うようにした。

プラットフォームごとにキーストアを自動的に変更する機能は実装していない。